### PR TITLE
Add contextPaths to sitewide audit attributes for issue modal Context…

### DIFF
--- a/standards/audits.json
+++ b/standards/audits.json
@@ -124,6 +124,7 @@
       },
       {
         "key": "status",
+        "contextPaths": ["/sitemap.xml"],
         "displayName": "Sitemap status",
         "featured": true,
         "tag": "Status",
@@ -157,6 +158,7 @@
       },
       {
         "key": "xml",
+        "contextPaths": ["/sitemap.xml"],
         "scorekey": "xml",
         "displayName": "Sitemap XML",
         "tag": "XML",
@@ -201,6 +203,7 @@
       },
       {
         "key": "valid",
+        "contextPaths": ["/robots.txt"],
         "scorekey": "valid",
         "displayName": "Robots valid",
         "featured": true,
@@ -245,6 +248,7 @@
       },
       {
         "key": "allowed",
+        "contextPaths": ["/robots.txt"],
         "scorekey": "allowed",
         "displayName": "Robots allowed",
         "tag": "Allowed",
@@ -293,6 +297,7 @@
       },
       {
         "key": "sitemap-robots",
+        "contextPaths": ["/robots.txt"],
         "scorekey": "sitemap-robots",
         "displayName": "Sitemap in robots.txt",
         "tag": "Sitemap",
@@ -2826,6 +2831,7 @@
       },
       {
         "key": "www",
+        "contextPaths": ["/"],
         "scorekey": "www",
         "displayName": "www resolution",
         "tag": "www",
@@ -3406,6 +3412,7 @@
       },
       {
         "key": "securitytxt",
+        "contextPaths": ["/security.txt", "/.well-known/security.txt"],
         "scorekey": "securitytxt",
         "displayName": "security.txt",
         "featured": true,
@@ -3571,6 +3578,7 @@
       },
       {
         "key": "https",
+        "contextPaths": ["/"],
         "scorekey": "https",
         "displayName": "Hypertext Transfer Protocol Secure (HTTPS)",
         "featured": true,


### PR DESCRIPTION
… links

Adds a contextPaths field to www, https, securitytxt, sitemap-robots, allowed, valid, xml, and status so my.scangov.com issue modals can link directly to the affected file/path on the scanned domain.

Refs #358