### PR TITLE
#538 Add problem, recommendation, scangovStatus, and statusDescriptio…

### DIFF
--- a/status.json
+++ b/status.json
@@ -3,84 +3,140 @@
     "code": 200,
     "label": "OK",
     "type": "active",
-    "description": "The request succeeded and the page loaded normally."
+    "description": "The request succeeded and the page loaded normally.",
+    "scangovStatus": "Scan successful",
+    "statusDescription": "We were able to fully scan your site.",
+    "problem": null,
+    "recommendation": null
   },
   {
     "code": 301,
     "label": "Moved Permanently",
     "type": "redirect",
-    "description": "The URL has permanently moved to a new address."
+    "description": "The URL has permanently moved to a new address.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "Links and search engines pointing to this URL land on a redirect instead of the final page, which can slow load times, dilute SEO signals, and cause automated scans that don't follow redirects to miss the real content.",
+    "recommendation": "Update internal links, sitemaps, and external references to point directly at the destination URL. Confirm the redirect is intentional and permanent, not a leftover from an old site migration."
   },
   {
     "code": 302,
     "label": "Found",
     "type": "redirect",
-    "description": "The URL has temporarily moved to a new address."
+    "description": "The URL has temporarily moved to a new address.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "Search engines treat this as a temporary move, so the original URL keeps its indexing weight even though visitors are sent elsewhere. It's easy to leave a 302 in place long after the move became permanent.",
+    "recommendation": "If the move is permanent, switch to a 301 redirect. If it's genuinely temporary, confirm the destination is correct and remove the redirect once it's no longer needed."
   },
   {
     "code": 400,
     "label": "Bad Request",
     "type": "inaccessible",
-    "description": "The server could not understand the request due to invalid syntax or formatting."
+    "description": "The server could not understand the request due to invalid syntax or formatting.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "The server rejected the request outright, so the page never loads for visitors, search engines, or AI crawlers hitting this URL.",
+    "recommendation": "Check the URL for malformed query parameters or encoding issues, and review server logs for the exact validation error being triggered."
   },
   {
     "code": 401,
     "label": "Unauthorized",
     "type": "inaccessible",
-    "description": "The requested resource requires authentication. The client must log in to access it."
+    "description": "The requested resource requires authentication. The client must log in to access it.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "This page is locked behind a login, so it's invisible to the public, search engines, and AI tools \u2014 even if it's meant to be publicly available.",
+    "recommendation": "If the page should be public, remove the authentication requirement. If it's intentionally private, remove it from your sitemap and any public-facing links."
   },
   {
     "code": 403,
     "label": "Forbidden",
     "type": "inaccessible",
-    "description": "The server understood the request but refused to fulfill it. The client does not have permission to access this resource."
+    "description": "The server understood the request but refused to fulfill it. The client does not have permission to access this resource.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "The server actively blocked access, which may indicate misconfigured permissions, a firewall rule, or a bot-blocking tool that's also blocking legitimate crawlers (like <a href=\"https://scangov.com/bot\">ScanGovBot</a>).",
+    "recommendation": "Review server/firewall rules and any bot-protection service (e.g. a WAF or Cloudflare) to confirm search engines and monitoring tools aren't being blocked unintentionally."
   },
   {
     "code": 404,
     "label": "Not Found",
     "type": "inaccessible",
-    "description": "The server could not find the requested page or resource."
+    "description": "The server could not find the requested page or resource.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "The page no longer exists at this address, creating a broken link for anyone who visits it, including from search results, bookmarks, or other sites linking here.",
+    "recommendation": "Restore the page at this URL, or set up a redirect to its new location or the closest relevant page. Update internal links and the sitemap to remove the dead URL."
   },
   {
     "code": 408,
     "label": "Request Timeout",
     "type": "inaccessible",
-    "description": "The server closed the connection because the request took too long to complete."
+    "description": "The server closed the connection because the request took too long to complete.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "The server took too long to respond, so the page failed to load \u2014 this can point to performance problems or an overloaded server.",
+    "recommendation": "Investigate server response times and resource usage. If timeouts are frequent, consider caching, scaling server resources, or optimizing slow backend queries."
   },
   {
     "code": 410,
     "label": "Gone",
     "type": "inaccessible",
-    "description": "The requested resource has been permanently removed and will not be available again."
+    "description": "The requested resource has been permanently removed and will not be available again.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "The page was intentionally and permanently removed, so anyone linking to it \u2014 including search engines \u2014 hits a dead end with no path forward.",
+    "recommendation": "If the content moved rather than disappeared, use a redirect instead of a 410. Otherwise, remove references to this URL from menus, sitemaps, and external links."
   },
   {
     "code": 429,
     "label": "Too Many Requests",
     "type": "inaccessible",
-    "description": "The client sent too many requests in a short period and the server is rate-limiting access."
+    "description": "The client sent too many requests in a short period and the server is rate-limiting access.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "The server is rate-limiting requests to this URL, which can prevent monitoring tools, search engines, or real visitors from reliably reaching the page during busy periods.",
+    "recommendation": "Review and relax rate-limiting thresholds for legitimate traffic, including known crawlers, or allowlist the scanning/monitoring service's IP."
   },
   {
     "code": 500,
     "label": "Internal Server Error",
     "type": "inaccessible",
-    "description": "The server encountered an unexpected error and could not complete the request."
+    "description": "The server encountered an unexpected error and could not complete the request.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "An unhandled error on the server prevented the page from loading at all, affecting every visitor who requests this URL.",
+    "recommendation": "Check server error logs for the underlying exception and fix the code or configuration issue causing the crash."
   },
   {
     "code": 502,
     "label": "Bad Gateway",
     "type": "inaccessible",
-    "description": "The server received an invalid response from another server while processing the request."
+    "description": "The server received an invalid response from another server while processing the request.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "A server acting as a proxy or gateway got an invalid response from an upstream server, so the page failed to load \u2014 often a sign of backend or infrastructure trouble.",
+    "recommendation": "Check the health of upstream/backend servers and the configuration of the proxy or load balancer sitting in front of them."
   },
   {
     "code": 503,
     "label": "Service Unavailable",
     "type": "inaccessible",
-    "description": "The server is temporarily unable to handle the request, often due to maintenance or overload."
+    "description": "The server is temporarily unable to handle the request, often due to maintenance or overload.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "The server can't currently handle the request, often due to maintenance or overload, so the page is temporarily unreachable.",
+    "recommendation": "If this is planned maintenance, confirm it's temporary and communicated to users. If it's overload, investigate server capacity and traffic spikes."
   },
   {
     "code": 999,
     "label": "Request Denied",
     "type": "inaccessible",
-    "description": "A non-standard code used by some sites to actively block automated or bot traffic."
+    "description": "A non-standard code used by some sites to actively block automated or bot traffic.",
+    "scangovStatus": "Scan failed",
+    "statusDescription": "We weren't able to fully scan your site.",
+    "problem": "The site is actively blocking automated tools, including this scanner, so its content can't be verified or indexed by anyone using similar tools.",
+    "recommendation": "Review bot-blocking rules to allow legitimate crawlers and monitoring services, or confirm this restriction on this URL is intentional."
   }
 ]


### PR DESCRIPTION
…n fields to status.json

Supports the new my.scangov.com Status page: problem/recommendation give plain-language impact and fix guidance per HTTP status code, scangovStatus is a pass/fail headline, and statusDescription is the one-sentence summary shown under it.