### PR TITLE
Fix npm dependency vulnerabilities via package.json overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,9 @@
   "dependencies": {
     "@11ty/font-awesome": "github:aaronhans/eleventy-plugin-font-awesome",
     "purgecss": "^7.0.2"
+  },
+  "overrides": {
+    "brace-expansion": "^1.1.18",
+    "postcss": "^8.5.25"
   }
 }


### PR DESCRIPTION
package-lock.json is gitignored here, so npm audit fix has nothing to commit. Pin brace-expansion and postcss to their patched versions via overrides instead, so the fix holds regardless of lockfile presence.

Part of ScanGov/scangov-com#193